### PR TITLE
Add scannetv2 dataset utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ __pycache__/
 # Generated files
 *.o
 *.so
+
+# virtualenv python
+venv

--- a/configs/scannetv2/max_deeplab/max_deeplab_s_os16_res641_100k.textproto
+++ b/configs/scannetv2/max_deeplab/max_deeplab_s_os16_res641_100k.textproto
@@ -1,0 +1,137 @@
+# proto-file: deeplab2/config.proto
+# proto-message: ExperimentOptions
+#
+# MaX-DeepLab-S with resolution 641x641 and 100k training steps.
+#
+############### PLEASE READ THIS BEFORE USING THIS CONFIG ###############
+# Before using this config, you need to update the following fields:
+# - experiment_name: Use a unique experiment name for each experiment.
+# - initial_checkpoint: Update the path to the initial checkpoint.
+# - train_dataset_options.file_pattern: Update the path to the
+#   training set. e.g., your_dataset/train*.tfrecord
+# - eval_dataset_options.file_pattern: Update the path to the
+#   validation set, e.g., your_dataset/eval*.tfrecord
+#########################################################################
+#
+# MaX-DeepLab-S replaces the last two stages of ResNet-50-beta with axial-
+# attention blocks and applies a small dual-path transformer.
+#
+# For axial-attention, see
+# - Huiyu Wang, et al. "Axial-DeepLab: Stand-Alone Axial-Attention for Panoptic
+#   Segmentation." In ECCV, 2020.
+# For MaX-DeepLab, see
+# - Huiyu Wang, et al. "MaX-DeepLab: End-to-End Panoptic Segmentation with Mask
+#   Transformers." In CVPR, 2021.
+
+# Use a unique experiment_name for each experiment.
+experiment_name: "max_deeplab_s_scannetv2_test"
+model_options {
+  # Update the path to the initial checkpoint (e.g., ImageNet
+  # pretrained checkpoint).
+  initial_checkpoint: "${INIT_CHECKPOINT}"
+  backbone {
+    name: "max_deeplab_s"
+    output_stride: 16
+    drop_path_keep_prob: 0.8
+    drop_path_schedule: "linear"
+  }
+  decoder {
+    feature_key: "feature_semantic"
+    decoder_channels: 256
+    aspp_channels: 256
+    atrous_rates: 6
+    atrous_rates: 12
+    atrous_rates: 18
+  }
+  max_deeplab {
+    pixel_space_head {
+      output_channels: 128
+      head_channels: 256
+    }
+    auxiliary_low_level {
+      feature_key: "res3"
+      channels_project: 64
+    }
+    auxiliary_low_level {
+      feature_key: "res2"
+      channels_project: 32
+    }
+    auxiliary_semantic_head {
+      output_channels: 134
+      head_channels: 256
+    }
+  }
+}
+trainer_options {
+  save_checkpoints_steps: 1000
+  save_summaries_steps: 100
+  steps_per_loop: 100
+  loss_options {
+    semantic_loss {
+      name: "softmax_cross_entropy"
+      weight: 1.0
+    }
+    pq_style_loss {
+      weight: 3.0
+    }
+    mask_id_cross_entropy_loss {
+      weight: 0.3
+    }
+    instance_discrimination_loss {
+      weight: 1.0
+    }
+  }
+  solver_options {
+    base_learning_rate: 0.001
+    training_number_of_steps: 100000
+    warmup_steps: 5000
+    backbone_learning_rate_multiplier: 0.1
+  }
+}
+train_dataset_options {
+  dataset: "scannetv2"
+  file_pattern: "${TRAIN_SET}"
+  # Adjust the batch_size accordingly to better fit your GPU/TPU memory.
+  # Also see Q1 in g3doc/faq.md.
+  batch_size: 64
+  crop_size: 641
+  crop_size: 641
+  min_resize_value: 641
+  max_resize_value: 641
+  augmentations {
+    min_scale_factor: 0.5
+    max_scale_factor: 1.5
+    scale_factor_step_size: 0.1
+  }
+  increase_small_instance_weights: false
+  small_instance_weight: 1.0
+  # This option generates ground truth labels for MaX-Deeplab.
+  thing_id_mask_annotations: true
+}
+eval_dataset_options {
+  dataset: "scannetv2"
+  # Update the path to validation set.
+  file_pattern: "${VAL_SET}"
+  batch_size: 1
+  crop_size: 641
+  crop_size: 641
+  min_resize_value: 641
+  max_resize_value: 641
+  # Add options to make the evaluation loss comparable to the training loss.
+  increase_small_instance_weights: false
+  small_instance_weight: 1.0
+  # This option generates ground truth labels for MaX-Deeplab.
+  thing_id_mask_annotations: true
+}
+evaluator_options {
+  continuous_eval_timeout: -1
+  thing_area_limit: 100
+  stuff_area_limit: 1600
+  transformer_class_confidence_threshold: 0.7
+  pixel_confidence_threshold: 0.4
+  save_predictions: true
+  save_raw_predictions: false
+  # Some options are inapplicable to MaX-DeepLab, including nms_kernel,
+  # merge_semantic_and_instance_with_tf_op, center_score_threshold,
+  # keep_k_centers, add_flipped_images, and eval_scales.
+}

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -119,8 +119,8 @@ def _get_color_and_panoptic_per_shard(
     dirs_to_remove = []
     for i, scan_id in enumerate(scan_ids):
         scan_dir_path = scans_root_dir_path / scan_id
-        if not scan_dir_path.exists():
-            logging.warning(f"Scan {scan_id} does not exist!")
+        if not scan_dir_path.is_dir():
+            logging.warning(f"Scan dir {str(scan_dir_path)} does not exist!")
             continue
 
         remove_color_files = False or remove_files

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -131,7 +131,7 @@ def _get_color_and_panoptic_per_shard(
         try:
             _extract_tar_archive(images_archive_path)
         except FileNotFoundError:
-            logging.warning(f"Scan {scan_id} color images not found. Skipped.")
+            logging.warning(f"{images_archive_path} not found. {scan_id} skipped.")
             continue
         images_dir_path = os.path.join(scan_dir_path, _IMAGES_DIR_NAME)
 
@@ -141,7 +141,7 @@ def _get_color_and_panoptic_per_shard(
         try:
             _extract_tar_archive(panoptic_maps_archive_path)
         except FileNotFoundError:
-            logging.warning(f"Scan {scan_id} panoptic_maps not found. Skipped.")
+            logging.warning(f"{panoptic_maps_archive_path} not found. {scan_id} skipped.")
             shutil.rmtree(str(images_dir_path))
             continue
 

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -292,12 +292,6 @@ def _parse_args():
         help="Number of shards.",
     )
 
-    parser.add_argument(
-        "--remove_files",
-        action="store_true",
-        help="Remove raw images and panoptic maps.",
-    )
-
     return parser.parse_args()
 
 
@@ -309,5 +303,4 @@ if __name__ == "__main__":
         output_dir_path=args.output_dir_path,
         scan_ids_file_path=args.scan_ids_file_path,
         num_shards=args.num_shards,
-        remove_files=args.remove_files,
     )

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -56,7 +56,8 @@ def _extract_tar_archive(tar_archive_path: str):
 
 def _load_scan_ids_from_file(scan_ids_file_path: str) -> List[str]:
     with open(scan_ids_file_path, "r") as f:
-        return f.readlines()
+        scan_ids = f.readlines()
+    return [s.rstrip('\n') for s in scan_ids]
 
 
 def _find_scans(scans_root_dir: str) -> List[str]:

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -8,7 +8,6 @@ import shutil
 import tarfile
 
 from typing import List, Tuple, Optional
-from pathlib import Path
 
 import numpy as np
 import tensorflow as tf

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -1,0 +1,292 @@
+import argparse
+import logging
+import re
+import shutil
+import tarfile
+
+from typing import List, Tuple, Optional
+from pathlib import Path
+
+import numpy as np
+import tensorflow as tf
+from PIL import Image
+
+from deeplab2.data import data_utils
+
+logging.basicConfig(level=logging.INFO)
+
+
+_PANOPTIC_LABEL_FORMAT = "raw"
+_TF_RECORD_PATTERN = "%s-%05d-of-%05d.tfrecord"
+_IMAGES_DIR_NAME = "color"
+_PANOPTIC_MAPS_DIR_NAME = "panoptic"
+_SCANS_SEARCH_PATTERN = "scene*"
+
+
+def _load_image(image_file_path: Path):
+    with tf.io.gfile.GFile(str(image_file_path), "rb") as f:
+        image_data = f.read()
+    return image_data
+
+
+def _load_panoptic_map(panoptic_map_path: Path) -> Optional[str]:
+    """Decodes the panoptic map from encoded image file.
+
+    Args:
+      panoptic_map_path: Path to the panoptic map image file.
+
+    Returns:
+      Panoptic map as an encoded int32 numpy array bytes or None if not existing.
+    """
+    with tf.io.gfile.GFile(str(panoptic_map_path), "rb") as f:
+        panoptic_map = np.array(Image.open(f)).astype(np.int32)
+    return panoptic_map.tobytes()
+
+
+def _extract_tar_archive(tar_archive_path: Path):
+    tar_archive = tarfile.open(str(tar_archive_path), "r:gz")
+    extract_dir_path = tar_archive_path.parent
+    tar_archive.extractall(
+        path=str(extract_dir_path),
+    )
+
+
+def _load_scan_ids_from_file(scan_ids_file_path: Path) -> List[str]:
+    with scan_ids_file_path.open("r") as f:
+        return f.readlines()
+
+
+def _find_scans(scans_root_dir: Path) -> List[str]:
+    scan_dirs = scans_root_dir.glob(_SCANS_SEARCH_PATTERN)
+    return [scan_dir.name for scan_dir in scan_dirs if scan_dir.is_dir()]
+
+
+def _get_image_info_from_path(image_path: Path) -> Tuple[str, str]:
+    """Gets image info including sequence id and image id.
+
+    Image path is in the format of '.../scan_id/color/image_id.png',
+    where `scan_id` refers to the id of the video sequence, and `image_id` is
+    the id of the image in the video sequence.
+
+    Args:
+      image_path: Absolute path of the image.
+
+    Returns:
+      sequence_id, and image_id as strings.
+    """
+    scan_id = image_path.parents[2].name
+    image_id = image_path.stem
+    return scan_id, image_id
+
+
+def _remove_dirs(dir_paths: List[Path]):
+    for dir_path in dir_paths:
+        shutil.rmtree(dir_path)
+
+
+def _get_color_and_panoptic_per_shard(
+    scans_root_dir_path: Path,
+    scan_ids: Optional[List[str]],
+    remove_files: bool = False,
+):
+    if scan_ids is None:
+        scan_ids = _find_scans(scans_root_dir_path)
+    color_and_panoptic_per_shard = []
+    dirs_to_remove = []
+    for i, scan_id in enumerate(scan_ids):
+        scan_dir_path = scans_root_dir_path / scan_id
+        if not scan_dir_path.exists():
+            logging.warning(f"Scan {scan_id} does not exist!")
+            continue
+
+        remove_color_files = False or remove_files
+        remove_panoptic_files = False or remove_files
+        images_dir_path = scan_dir_path / _IMAGES_DIR_NAME
+        if not images_dir_path.exists():
+            images_archive_path = scan_dir_path / f"{_IMAGES_DIR_NAME}.tar.gz"
+            if not images_archive_path.exists():
+                logging.warning(f"Scan {scan_id} color images not found. Skipped.")
+                continue
+            _extract_tar_archive(images_archive_path)
+            remove_color_files = True
+
+        panoptic_maps_dir_path = scan_dir_path / _PANOPTIC_MAPS_DIR_NAME
+        if not panoptic_maps_dir_path.exists():
+            panoptic_maps_archive_path = (
+                scan_dir_path / f"{_PANOPTIC_MAPS_DIR_NAME}.tar.gz"
+            )
+            if not panoptic_maps_archive_path.exists():
+                if remove_color_files:
+                    shutil.rmtree(str(images_dir_path))
+                logging.warning(f"Scan {scan_id} panoptic_maps not found. Skipped.")
+                continue
+            _extract_tar_archive(panoptic_maps_archive_path)
+            remove_panoptic_files = True
+
+        image_file_paths = list(images_dir_path.glob("*.jpg"))
+        for j, image_file_path in enumerate(image_file_paths):
+            image_file_name = image_file_path.stem
+            panoptic_map_file_path = panoptic_maps_dir_path / (
+                re.sub(r"0+(.+)", r"\1", image_file_name) + ".png"
+            )
+            if not panoptic_map_file_path.exists():
+                logging.warning(
+                    f"Panoptic map not found for image {image_file_name} in scan {scan_id}"
+                )
+                continue
+
+            color_and_panoptic_per_shard.append(
+                (image_file_path, panoptic_map_file_path)
+            )
+
+            shard_data = len(color_and_panoptic_per_shard) == 10 or (
+                # Last image of the last scan in the list
+                j == len(image_file_paths)
+                and i == len(scan_ids)
+            )
+            if shard_data:
+                yield color_and_panoptic_per_shard
+                # Remove all the directories that can be removed
+                _remove_dirs(dirs_to_remove)
+                dirs_to_remove = []
+
+        if remove_color_files:
+            dirs_to_remove.append(images_dir_path)
+
+        if remove_panoptic_files:
+            dirs_to_remove.append(panoptic_maps_dir_path)
+
+    # Clean up the last dirs
+    _remove_dirs(dirs_to_remove)
+
+
+def _create_panoptic_tfexample(
+    image_path: Path,
+    panoptic_map_path: Path,
+) -> tf.train.Example:
+    """Creates a TF example for each image.
+
+    Args:
+      image_path: Path to the image.
+      panoptic_map_path: Path to the panoptic map (as an image file).
+
+    Returns:
+      TF example proto.
+    """
+    image_data = _load_image(image_path)
+    label_data = _load_panoptic_map(panoptic_map_path)
+    image_name = image_path.name
+    image_format = image_path.suffix.lstrip(".").lower()
+    sequence_id, frame_id = _get_image_info_from_path(image_path)
+    return data_utils.create_video_tfexample(
+        image_data,
+        image_format,
+        image_name,
+        label_format=_PANOPTIC_LABEL_FORMAT,
+        sequence_id=sequence_id,
+        image_id=frame_id,
+        label_data=label_data,
+        prev_image_data=None,
+        prev_label_data=None,
+    )
+
+
+def _create_tf_record_dataset(
+    scans_root_dir_path: Path,
+    dataset_tag: str,
+    output_dir_path: Path,
+    num_shards: int,
+    scan_ids_file_path: Optional[Path],
+    remove_files: bool = False,
+):
+    assert scans_root_dir_path.is_dir()
+
+    output_dir_path.mkdir(exist_ok=True, parents=True)
+
+    scan_ids = None
+    if scan_ids_file_path is not None:
+        assert scan_ids_file_path.exists()
+        scan_ids = _load_scan_ids_from_file(scan_ids_file_path)
+
+    color_and_panoptic_per_shard = _get_color_and_panoptic_per_shard(
+        scans_root_dir_path=scans_root_dir_path,
+        scan_ids=scan_ids,
+        remove_files=remove_files,
+    )
+
+    for shard_id, example_list in enumerate(color_and_panoptic_per_shard):
+        shard_filename = _TF_RECORD_PATTERN % (dataset_tag, shard_id, num_shards)
+        shard_file_path = output_dir_path / shard_filename
+        with tf.io.TFRecordWriter(str(shard_file_path)) as tfrecord_writer:
+            for image_path, panoptic_map_path in example_list:
+                example = _create_panoptic_tfexample(
+                    image_path,
+                    panoptic_map_path,
+                )
+                tfrecord_writer.write(example.SerializeToString())
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Converts scans from the ScanNetV2 dataset to TFRecord",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    parser.add_argument(
+        "-sd",
+        "--scans_root_dir_path",
+        type=lambda p: Path(p).absolute(),
+        required=True,
+        help="Scans root directory.",
+    )
+
+    parser.add_argument(
+        "-o",
+        "--output_dir_path",
+        type=lambda p: Path(p).absolute(),
+        required=True,
+        help="Path to save converted TFRecord of TensorFlow examples.",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--dataset_tag",
+        type=str,
+        required=True,
+        help="Dataset tag. All the shards will be named as ...",
+    )
+
+    parser.add_argument(
+        "-ids",
+        "--scan_ids_file_path",
+        type=lambda p: Path(p).absolute(),
+        help="Path to a text file with the ids of the scans to consider.",
+    )
+
+    parser.add_argument(
+        "-ns",
+        "--num_shards",
+        type=int,
+        default=1000,
+        help="Number of shards.",
+    )
+
+    parser.add_argument(
+        "--remove_files",
+        action="store_true",
+        help="Remove raw images and panoptic maps.",
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = _parse_args()
+    _create_tf_record_dataset(
+        scans_root_dir_path=args.scans_root_dir_path,
+        dataset_tag=args.dataset_tag,
+        output_dir_path=args.output_dir_path,
+        scan_ids_file_path=args.scan_ids_file_path,
+        num_shards=args.num_shards,
+        remove_files=args.remove_files,
+    )

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -101,7 +101,7 @@ def _compute_total_number_of_frames(
         scan_info_file_path = os.path.join(
             scans_root_dir_path, scan_id, f"{scan_id}.txt"
         )
-        if not tf.io.gfile.exists(str(scan_info_file_path)):
+        if not tf.io.gfile.exists(scan_info_file_path):
             logging.error(f"Scan info file missing in {scan_id}!")
             continue
         with tf.io.gfile.GFile(scan_info_file_path, "r") as f:
@@ -127,7 +127,7 @@ def _get_color_and_panoptic_per_shard(
     dirs_to_remove = []
     for i, scan_id in enumerate(scan_ids):
         scan_dir_path = os.path.join(scans_root_dir_path, scan_id)
-        if not tf.io.gfile.exists(scan_dir_path):
+        if not tf.io.gfile.isdir(scan_dir_path):
             logging.warning(f"Scan dir {str(scan_dir_path)} does not exist!")
             continue
 
@@ -145,7 +145,7 @@ def _get_color_and_panoptic_per_shard(
             remove_color_files = True
 
         panoptic_maps_dir_path = os.path.join(scan_dir_path, _PANOPTIC_MAPS_DIR_NAME)
-        if not tf.io.gfile.exists(panoptic_maps_dir_path):
+        if not tf.io.gfile.isdir(panoptic_maps_dir_path):
             panoptic_maps_archive_path = os.path.join(
                 scan_dir_path, f"{_PANOPTIC_MAPS_DIR_NAME}.tar.gz"
             )

--- a/data/build_scannetv2_data.py
+++ b/data/build_scannetv2_data.py
@@ -93,7 +93,7 @@ def _compute_total_number_of_frames(
     cnt = 0
     for scan_id in scan_ids:
         scan_info_file_path = scans_root_dir_path / scan_id / f"{scan_id}.txt"
-        if not scan_info_file_path.exists():
+        if not tf.io.gfile.exists(str(scan_info_file_path)):
             logging.error(f"Scan info file missing in {scan_id}!")
             continue
         with scan_info_file_path.open("r") as f:
@@ -119,27 +119,27 @@ def _get_color_and_panoptic_per_shard(
     dirs_to_remove = []
     for i, scan_id in enumerate(scan_ids):
         scan_dir_path = scans_root_dir_path / scan_id
-        if not scan_dir_path.is_dir():
+        if not tf.io.gfile.exists(str(scan_dir_path)):
             logging.warning(f"Scan dir {str(scan_dir_path)} does not exist!")
             continue
 
         remove_color_files = False or remove_files
         remove_panoptic_files = False or remove_files
         images_dir_path = scan_dir_path / _IMAGES_DIR_NAME
-        if not images_dir_path.exists():
+        if not tf.io.gfile.isdir(str(images_dir_path)):
             images_archive_path = scan_dir_path / f"{_IMAGES_DIR_NAME}.tar.gz"
-            if not images_archive_path.exists():
+            if not tf.io.gfile.exists(str(images_archive_path)):
                 logging.warning(f"Scan {scan_id} color images not found. Skipped.")
                 continue
             _extract_tar_archive(images_archive_path)
             remove_color_files = True
 
         panoptic_maps_dir_path = scan_dir_path / _PANOPTIC_MAPS_DIR_NAME
-        if not panoptic_maps_dir_path.exists():
+        if not tf.io.gfile.exists(str(panoptic_maps_dir_path)):
             panoptic_maps_archive_path = (
                 scan_dir_path / f"{_PANOPTIC_MAPS_DIR_NAME}.tar.gz"
             )
-            if not panoptic_maps_archive_path.exists():
+            if not tf.io.gfile.exists(str(panoptic_maps_archive_path)):
                 if remove_color_files:
                     shutil.rmtree(str(images_dir_path))
                 logging.warning(f"Scan {scan_id} panoptic_maps not found. Skipped.")
@@ -153,7 +153,7 @@ def _get_color_and_panoptic_per_shard(
             panoptic_map_file_path = panoptic_maps_dir_path / (
                 re.sub(r"0+(.+)", r"\1", image_file_name) + ".png"
             )
-            if not panoptic_map_file_path.exists():
+            if tf.io.gfile.exists(str(panoptic_map_file_path)):
                 logging.warning(
                     f"Panoptic map not found for image {image_file_name} in scan {scan_id}"
                 )
@@ -226,13 +226,13 @@ def _create_tf_record_dataset(
     scan_ids_file_path: Optional[Path],
     remove_files: bool = False,
 ):
-    assert scans_root_dir_path.is_dir()
+    assert tf.io.gfile.isdir(str(scans_root_dir_path))
 
     output_dir_path.mkdir(exist_ok=True, parents=True)
 
     scan_ids = None
     if scan_ids_file_path is not None:
-        assert scan_ids_file_path.exists()
+        assert tf.io.gfile.exists(str(scan_ids_file_path))
         scan_ids = _load_scan_ids_from_file(scan_ids_file_path)
 
     color_and_panoptic_per_shard = _get_color_and_panoptic_per_shard(

--- a/data/utils/create_scannetv2_panoptic_maps.py
+++ b/data/utils/create_scannetv2_panoptic_maps.py
@@ -237,7 +237,7 @@ def create_scannetv2_panoptic_maps(_):
     # Loop over all the scans
     scan_dir_paths = sorted(list(scans_root_dir_path.glob("scene*")))
     with multiprocessing.Pool(processes=n_jobs) as p:
-        p.starmap(job_fn, scan_dir_paths)
+        p.map(job_fn, scan_dir_paths)
 
 
 if __name__ == "__main__":

--- a/data/utils/create_scannetv2_panoptic_maps.py
+++ b/data/utils/create_scannetv2_panoptic_maps.py
@@ -1,0 +1,143 @@
+import math
+from pathlib import Path
+
+from typing import Dict, Iterator, Sequence, Tuple, Optional
+
+from absl import app
+from absl import flags
+from absl import logging
+import numpy as np
+
+from PIL import Image
+
+import pandas as pd
+
+import tensorflow as tf
+
+from deeplab2.data import data_utils
+
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    name="labels_tsv_path",
+    default=None,
+    help="Path to the combined-labels.tsv file of the ScanNetV2 dataset",
+)
+flags.DEFINE_enum(
+    name="labels_set",
+    default="nyu40id",
+    enum_values=["nyu40id"],
+    help="Name of the dataset",
+)
+flags.DEFINE_string(
+    name="semantic_maps_dir_path",
+    default=None,
+    help="Path to a directory containing the semantic maps.",
+)
+flags.DEFINE_string(
+    name="instance_maps_dir_path",
+    default=None,
+    help="Path to a directory containing the instance map.",
+)
+flags.DEFINE_string(
+    name="output_dir_path",
+    default=None,
+    help="Path to a directory where we write the panoptic map.",
+)
+
+
+# Same as Cityscapes
+_LABEL_DIVISOR = 255
+
+
+def convert_semantic_map_labels(semantic_map: np.ndarray, label_conversion_dict: Dict):
+    return np.vectorize(label_conversion_dict.get)(semantic_map)
+
+
+def create_label_conversion_dict(label_conversion_table: pd.DataFrame, labels_set: str):
+    scannetv2_label_ids = label_conversion_table["id"].tolist()
+    target_label_ids = label_conversion_table[labels_set].tolist()
+
+    # Match ids and create ids
+    label_conversion_dict = dict(zip(scannetv2_label_ids, target_label_ids))
+
+    # Add zero
+    label_conversion_dict[0] = 0
+
+    return label_conversion_dict
+
+
+def normalize_instance_map(instance_map: np.ndarray):
+    instance_ids = np.unique(instance_map).tolist()
+    # Remove 0 if present
+    try:
+        instance_ids.remove(0)
+    except ValueError:
+        pass
+
+    # Generate new instance ids
+    new_instance_ids = [i for i in range(1, len(instance_ids) + 1)]
+
+    # Create conversion dict
+    conversion_dict = dict(zip(instance_ids, new_instance_ids))
+    conversion_dict[0] = 0
+
+    # Now convert the instance map
+    return np.vectorize(conversion_dict.get)(instance_map)
+
+
+def create_deeplab2_panoptic_map(semantic_map: np.ndarray, instance_map: np.ndarray):
+    panoptic_map = semantic_map * _LABEL_DIVISOR + instance_map
+    return panoptic_map.astype(np.int32)
+
+
+def main(argv):
+    # Validate input args
+    semantic_maps_dir_path = Path(FLAGS.semantic_maps_dir_path)
+    assert semantic_maps_dir_path.exists()
+    instance_maps_dir_path = Path(FLAGS.instance_maps_dir_path)
+    assert instance_maps_dir_path.exists()
+    labels_tsv_path = Path(FLAGS.labels_tsv_path)
+    assert labels_tsv_path.exists()
+
+    # Load the labels conversion table - use the scannetv2 id as index
+    label_conversion_master_table = pd.reas_csv(str(labels_tsv_path), sep="\t")
+    label_conversion_dict = create_label_conversion_dict(
+        label_conversion_master_table, FLAGS.labels_set
+    )
+
+    # Create the output directory
+    output_dir_path = Path(FLAGS.output_dir_path)
+    output_dir_path.mkdir(exist_ok=True, parents=True)
+
+    # Loop over all the semantic label images
+    for semantic_map_file_path in semantic_maps_dir_path.glob("*.png"):
+        instance_map_file_path = instance_maps_dir_path / semantic_map_file_path.name
+        if not instance_map_file_path.exists():
+            continue
+        # Load semantic and instance map
+        semantic_map = np.array(Image.open(str(semantic_map_file_path)))
+        instance_map = np.array(Image.open(str(instance_map_file_path)))
+
+        # Convert the semantic labels
+        nyu40_semantic_map = convert_semantic_map_labels(
+            semantic_map, label_conversion_dict
+        )
+
+        # Normalize the instance map so that all the instance ids are between 1 and #instances
+        normalized_instanced_map = normalized_instanced_map(instance_map)
+
+        # Create panoptic map
+        panoptic_map = create_deeplab2_panoptic_map(
+            nyu40_semantic_map, normalized_instanced_map
+        )
+
+        # Save the panoptic map as png
+        panoptic_map_file_path = output_dir_path / semantic_map_file_path.name
+        panoptic_map_image = Image.fromarray(panoptic_map)
+        panoptic_map_image.save(str(panoptic_map_file_path))
+
+
+if __name__ == "__main__":
+    app.run(main)

--- a/data/utils/create_scannetv2_panoptic_maps.py
+++ b/data/utils/create_scannetv2_panoptic_maps.py
@@ -1,20 +1,13 @@
-import math
 from pathlib import Path
+import numpy as np
+import pandas as pd
 
-from typing import Dict, Iterator, Sequence, Tuple, Optional
+from typing import Dict
 
 from absl import app
 from absl import flags
 from absl import logging
-import numpy as np
-
 from PIL import Image
-
-import pandas as pd
-
-import tensorflow as tf
-
-from deeplab2.data import data_utils
 
 
 FLAGS = flags.FLAGS
@@ -31,21 +24,10 @@ flags.DEFINE_enum(
     help="Name of the dataset",
 )
 flags.DEFINE_string(
-    name="semantic_maps_dir_path",
+    name="scans_root_dir_path",
     default=None,
-    help="Path to a directory containing the semantic maps.",
+    help="Path to a directory containing scans as subdirs.",
 )
-flags.DEFINE_string(
-    name="instance_maps_dir_path",
-    default=None,
-    help="Path to a directory containing the instance map.",
-)
-flags.DEFINE_string(
-    name="output_dir_path",
-    default=None,
-    help="Path to a directory where we write the panoptic map.",
-)
-
 
 # Same as Cityscapes
 _LABEL_DIVISOR = 255
@@ -92,52 +74,72 @@ def create_deeplab2_panoptic_map(semantic_map: np.ndarray, instance_map: np.ndar
     return panoptic_map.astype(np.int32)
 
 
-def main(argv):
+def create_scannetv2_panoptic_maps(_):
     # Validate input args
-    semantic_maps_dir_path = Path(FLAGS.semantic_maps_dir_path)
-    assert semantic_maps_dir_path.exists()
-    instance_maps_dir_path = Path(FLAGS.instance_maps_dir_path)
-    assert instance_maps_dir_path.exists()
+    scans_root_dir_path = Path(FLAGS.scans_root_dir_path)
+    assert scans_root_dir_path.exists()
     labels_tsv_path = Path(FLAGS.labels_tsv_path)
     assert labels_tsv_path.exists()
 
     # Load the labels conversion table - use the scannetv2 id as index
-    label_conversion_master_table = pd.reas_csv(str(labels_tsv_path), sep="\t")
+    label_conversion_master_table = pd.read_csv(str(labels_tsv_path), sep="\t")
     label_conversion_dict = create_label_conversion_dict(
         label_conversion_master_table, FLAGS.labels_set
     )
 
-    # Create the output directory
-    output_dir_path = Path(FLAGS.output_dir_path)
-    output_dir_path.mkdir(exist_ok=True, parents=True)
-
-    # Loop over all the semantic label images
-    for semantic_map_file_path in semantic_maps_dir_path.glob("*.png"):
-        instance_map_file_path = instance_maps_dir_path / semantic_map_file_path.name
-        if not instance_map_file_path.exists():
+    # Loop over all the scans
+    for scan_dir_path in scans_root_dir_path.iterdir():
+        if not scan_dir_path.is_dir():
             continue
-        # Load semantic and instance map
-        semantic_map = np.array(Image.open(str(semantic_map_file_path)))
-        instance_map = np.array(Image.open(str(instance_map_file_path)))
+        semantic_maps_dir_path = scan_dir_path / "label-filt"
+        instance_maps_dir_path = scan_dir_path / "instance-filt"
+        if not semantic_maps_dir_path.exists():
+            logging.warn(
+                '"label-filt" missing in scan {}. Skipped.'.format(
+                    str(scan_dir_path.name)
+                )
+            )
+            continue
+        if not instance_maps_dir_path.exists():
+            logging.warn(
+                '"instance-filt" missing in scan {}. Skipped.'.format(
+                    str(scan_dir_path.name)
+                )
+            )
+            continue
 
-        # Convert the semantic labels
-        nyu40_semantic_map = convert_semantic_map_labels(
-            semantic_map, label_conversion_dict
-        )
+        panoptic_maps_dir_path = scan_dir_path / "panoptic"
+        panoptic_maps_dir_path.mkdir(exist_ok=True)
+        for semantic_map_file_path in semantic_maps_dir_path.glob("*.png"):
+            instance_map_file_path = (
+                instance_maps_dir_path / semantic_map_file_path.name
+            )
+            if not instance_map_file_path.exists():
+                continue
+            # Load semantic and instance map
+            semantic_map = np.array(Image.open(str(semantic_map_file_path)))
+            instance_map = np.array(Image.open(str(instance_map_file_path)))
 
-        # Normalize the instance map so that all the instance ids are between 1 and #instances
-        normalized_instanced_map = normalized_instanced_map(instance_map)
+            # Convert the semantic labels
+            nyu40_semantic_map = convert_semantic_map_labels(
+                semantic_map, label_conversion_dict
+            )
 
-        # Create panoptic map
-        panoptic_map = create_deeplab2_panoptic_map(
-            nyu40_semantic_map, normalized_instanced_map
-        )
+            # Normalize the instance map so that all the instance ids are between 1 and #instances
+            normalized_instanced_map = normalize_instance_map(instance_map)
 
-        # Save the panoptic map as png
-        panoptic_map_file_path = output_dir_path / semantic_map_file_path.name
-        panoptic_map_image = Image.fromarray(panoptic_map)
-        panoptic_map_image.save(str(panoptic_map_file_path))
+            # Create panoptic map
+            panoptic_map = create_deeplab2_panoptic_map(
+                nyu40_semantic_map, normalized_instanced_map
+            )
+
+            # Save the panoptic map as png
+            panoptic_map_file_path = (
+                panoptic_maps_dir_path / semantic_map_file_path.name
+            )
+            panoptic_map_image = Image.fromarray(panoptic_map)
+            panoptic_map_image.save(str(panoptic_map_file_path))
 
 
 if __name__ == "__main__":
-    app.run(main)
+    app.run(create_scannetv2_panoptic_maps)

--- a/data/utils/create_scannetv2_panoptic_maps.py
+++ b/data/utils/create_scannetv2_panoptic_maps.py
@@ -1,14 +1,17 @@
+import functools
 from pathlib import Path
 import numpy as np
 import pandas as pd
 
 from typing import Dict
 
+
 from absl import app
 from absl import flags
 from absl import logging
 from PIL import Image
 
+from joblib import Parallel, delayed
 
 FLAGS = flags.FLAGS
 
@@ -28,6 +31,8 @@ flags.DEFINE_string(
     default=None,
     help="Path to a directory containing scans as subdirs.",
 )
+
+flags.DEFINE_integer(name="jobs", default=2, help="Number of parallel jobs")
 
 # Same as Cityscapes
 _LABEL_DIVISOR = 255
@@ -69,9 +74,40 @@ def normalize_instance_map(instance_map: np.ndarray):
     return np.vectorize(conversion_dict.get)(instance_map)
 
 
-def create_deeplab2_panoptic_map(semantic_map: np.ndarray, instance_map: np.ndarray):
+def make_panoptic_from_semantic_and_instance(
+    semantic_map: np.ndarray,
+    instance_map: np.ndarray,
+):
     panoptic_map = semantic_map * _LABEL_DIVISOR + instance_map
     return panoptic_map.astype(np.int32)
+
+
+def generate_deeplab2_panoptic_map(
+    semantic_map_file_path: Path,
+    instance_map_file_path: Path,
+    panoptic_maps_dir_path: Path,
+    label_conversion_dict: Dict,
+):
+    semantic_map = np.array(Image.open(str(semantic_map_file_path)))
+    instance_map = np.array(Image.open(str(instance_map_file_path)))
+
+    # Convert semantic labels to the target labels set
+    converted_semantic_map = convert_semantic_map_labels(
+        semantic_map, label_conversion_dict
+    )
+
+    # Normalize the instance map so that all the instance ids are between 1 and #instances
+    normalized_instanced_map = normalize_instance_map(instance_map)
+
+    # Make panoptic map
+    panoptic_map = make_panoptic_from_semantic_and_instance(
+        converted_semantic_map, normalized_instanced_map
+    )
+
+    # Save panoptic map to disk
+    panoptic_map_file_path = panoptic_maps_dir_path / semantic_map_file_path.name
+    panoptic_map_image = Image.fromarray(panoptic_map)
+    panoptic_map_image.save(str(panoptic_map_file_path))
 
 
 def create_scannetv2_panoptic_maps(_):
@@ -80,6 +116,8 @@ def create_scannetv2_panoptic_maps(_):
     assert scans_root_dir_path.exists()
     labels_tsv_path = Path(FLAGS.labels_tsv_path)
     assert labels_tsv_path.exists()
+    n_jobs = FLAGS.jobs
+    assert n_jobs > 0
 
     # Load the labels conversion table - use the scannetv2 id as index
     label_conversion_master_table = pd.read_csv(str(labels_tsv_path), sep="\t")
@@ -110,35 +148,20 @@ def create_scannetv2_panoptic_maps(_):
 
         panoptic_maps_dir_path = scan_dir_path / "panoptic"
         panoptic_maps_dir_path.mkdir(exist_ok=True)
-        for semantic_map_file_path in semantic_maps_dir_path.glob("*.png"):
-            instance_map_file_path = (
-                instance_maps_dir_path / semantic_map_file_path.name
-            )
-            if not instance_map_file_path.exists():
-                continue
-            # Load semantic and instance map
-            semantic_map = np.array(Image.open(str(semantic_map_file_path)))
-            instance_map = np.array(Image.open(str(instance_map_file_path)))
 
-            # Convert the semantic labels
-            nyu40_semantic_map = convert_semantic_map_labels(
-                semantic_map, label_conversion_dict
-            )
+        semantic_map_files = sorted(list(semantic_maps_dir_path.glob("*.png")))
+        instance_map_files = sorted(list(instance_maps_dir_path.glob("*.png")))
 
-            # Normalize the instance map so that all the instance ids are between 1 and #instances
-            normalized_instanced_map = normalize_instance_map(instance_map)
+        job_fn = functools.partial(
+            generate_deeplab2_panoptic_map,
+            panoptic_maps_dir_path=panoptic_maps_dir_path,
+            label_conversion_dict=label_conversion_dict,
+        )
 
-            # Create panoptic map
-            panoptic_map = create_deeplab2_panoptic_map(
-                nyu40_semantic_map, normalized_instanced_map
-            )
-
-            # Save the panoptic map as png
-            panoptic_map_file_path = (
-                panoptic_maps_dir_path / semantic_map_file_path.name
-            )
-            panoptic_map_image = Image.fromarray(panoptic_map)
-            panoptic_map_image.save(str(panoptic_map_file_path))
+        Parallel(n_jobs=n_jobs)(
+            delayed(job_fn)(s, i)
+            for s, i in zip(semantic_map_files, instance_map_files)
+        )
 
 
 if __name__ == "__main__":

--- a/data/utils/create_scannetv2_panoptic_maps.py
+++ b/data/utils/create_scannetv2_panoptic_maps.py
@@ -46,6 +46,18 @@ _SEMANTIC_MAPS_ARCHIVE_SUFFIX = "_2d-label-filt.zip"
 _SEMANTIC_MAPS_DIR_NAME = "label-filt"
 _INSTANCE_MAPS_ARCHIVE_SUFFIX = "_2d-instance-filt.zip"
 _INSTANCE_MAPS_DIR_NAME = "instance-filt"
+_PANOPTIC_MAPS_DIR_NAME = "panoptic"
+
+def _scan_has_panoptic(scan_dir_path: Path):
+    panoptic_maps_dir_path = scan_dir_path / _PANOPTIC_MAPS_DIR_NAME
+    if panoptic_maps_dir_path.exists() and any(panoptic_maps_dir_path.iterdir()):
+        return True
+
+    panoptic_maps_archive_path = panoptic_maps_dir_path.with_suffix(".tar.gz") 
+    if panoptic_maps_archive_path.exists():
+        return True
+
+    return False
 
 
 def extract_zip_archive(path_to_zip_archive: Path):
@@ -148,9 +160,10 @@ def create_scannetv2_panoptic_maps(_):
             continue
 
         # Check if panoptic maps have already been created for this scans
-        panoptic_maps_dir_path = scan_dir_path / "panoptic"
-        if panoptic_maps_dir_path.exists() and any(panoptic_maps_dir_path.iterdir()):
+        if _scan_has_panoptic(scan_dir_path):
+            logging.warn(f"{scan_dir_path.name} already has panoptic!")
             continue
+        panoptic_maps_dir_path = scan_dir_path / _PANOPTIC_MAPS_DIR_NAME
         panoptic_maps_dir_path.mkdir(exist_ok=True)
 
         semantic_maps_dir_path = scan_dir_path / _SEMANTIC_MAPS_DIR_NAME

--- a/trainer/vis_utils.py
+++ b/trainer/vis_utils.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import PIL
 import tensorflow as tf
+from data.utils.create_scannetv2_panoptic_maps import create_label_conversion_dict
 
 from deeplab2.data import coco_constants
 
@@ -388,6 +389,55 @@ def create_coco_label_colormap():
     colormap[category['id']] = category['color']
   return colormap
 
+def create_scannetv2_nyu40_label_colormap():
+  """Creates a label colormap for the ScanNetV2 indoor segmentation benchmark.
+
+  Returns:
+    A colormap for visualizing segmentation results.
+  """
+  colormap = np.zeros((256, 3), dtype=np.uint8)
+  colormap[0] = [128, 64, 128]
+  colormap[1] = [244, 35, 232]
+  colormap[2] = [70, 70, 70]
+  colormap[3] = [102, 102, 156]
+  colormap[4] = [190, 153, 153]
+  colormap[5] = [153, 153, 153]
+  colormap[6] = [250, 170, 30]
+  colormap[7] = [220, 220, 0]
+  colormap[8] = [107, 142, 35]
+  colormap[9] = [152, 251, 152]
+  colormap[10] = [70, 130, 180]
+  colormap[11] = [220, 20, 60]
+  colormap[12] = [255, 0, 0]
+  colormap[13] = [0, 0, 142]
+  colormap[14] = [0, 0, 70]
+  colormap[15] = [0, 60, 100]
+  colormap[16] = [0, 80, 100]
+  colormap[17] = [0, 0, 230]
+  colormap[18] = [119, 11, 32]
+  colormap[19] = [220, 20, 60]
+  colormap[20] = [255, 0, 0]
+  colormap[21] = [0, 0, 142]
+  colormap[22] = [0, 0, 70]
+  colormap[23] = [0, 60, 100]
+  colormap[24] = [0, 80, 100]
+  colormap[25] = [0, 0, 230]
+  colormap[26] = [119, 11, 32]
+  colormap[27] = [119, 11, 32]
+  colormap[28] = [119, 11, 32]
+  colormap[29] = [119, 11, 32]
+  colormap[30] = [119, 11, 32]
+  colormap[31] = [119, 11, 32]
+  colormap[32] = [119, 11, 32]
+  colormap[33] = [119, 11, 32]
+  colormap[34] = [119, 11, 32]
+  colormap[35] = [119, 11, 32]
+  colormap[36] = [119, 11, 32]
+  colormap[37] = [119, 11, 32]
+  colormap[38] = [119, 11, 32]
+  colormap[39] = [119, 11, 32]
+  return colormap
+
 
 def label_to_color_image(label, colormap_name='cityscapes'):
   """Adds color defined by the colormap derived from the dataset to the label.
@@ -420,6 +470,8 @@ def label_to_color_image(label, colormap_name='cityscapes'):
     colormap = create_motchallenge_label_colormap()
   elif colormap_name == 'coco':
     colormap = create_coco_label_colormap()
+  elif colormap_name == 'scannetv2_nyu40':
+    colormap = create_scannetv2_nyu40_label_colormap()
   else:
     raise ValueError('Could not find a colormap for dataset %s.' %
                      colormap_name)


### PR DESCRIPTION
Add create_scannetv2_panoptic_maps.py to create deeplab2
compatible panoptic maps from instance and semantic labels
for the ScanNetV2 dataset.

Add script build_scannetv2_data.py to create a TFRecord
dataset for panoptic segmentation from the ScanNetV2 
dataset. The script assumes color images and panoptic maps
have already been extracted / created and compressed
into tar.gz archives. 