### PR TITLE
Set instance id of stuff classes to zero when create panoptic

### DIFF
--- a/data/dataset.py
+++ b/data/dataset.py
@@ -99,11 +99,13 @@ _MOTCHALLENGE_STEP = 'motchallenge_step'
 _CITYSCAPES_DVPS = 'cityscapes_dvps'
 _SEMKITTI_DVPS = 'semkitti_dvps'
 _COCO_PANOPTIC = 'coco_panoptic'
+_SCANNETV2_NYU40 = "scannetv2_nyu40"
 
 # Colormap names.
 _CITYSCAPES_COLORMAP = 'cityscapes'
 _MOTCHALLENGE_COLORMAP = 'motchallenge'
 _COCO_COLORMAP = 'coco'
+_SCANNETV2_NYU40_COLORMAP = 'scannetv2_nyu40'
 
 
 # Named tuple to describe dataset properties.
@@ -231,6 +233,28 @@ COCO_PANOPTIC_INFORMATION = DatasetDescriptor(
     ignore_depth=None,
 )
 
+SCANNETV2_NYU40_INFORMATION = DatasetDescriptor(
+    dataset_name=_SCANNETV2_NYU40,
+    splits_to_sizes={'train': 2500000,
+                     'val': 200000,
+                     'test': 20000},
+    # The ignore class is also included
+    num_classes=41,
+    ignore_label=0,
+    panoptic_label_divisor=255,
+    class_has_instances_list=tuple([
+      i for i in range(1, 41) if i not in [
+        1,  # wall
+        2,  # floor
+        22, # ceiling
+      ]
+    ]),
+    is_video_dataset=False,
+    colormap=_SCANNETV2_NYU40_COLORMAP,
+    is_depth_dataset=False,
+    ignore_depth=None,
+)
+
 MAP_NAME_TO_DATASET_INFO = {
     _CITYSCAPES_PANOPTIC: CITYSCAPES_PANOPTIC_INFORMATION,
     _KITTI_STEP: KITTI_STEP_INFORMATION,
@@ -238,6 +262,7 @@ MAP_NAME_TO_DATASET_INFO = {
     _CITYSCAPES_DVPS: CITYSCAPES_DVPS_INFORMATION,
     _COCO_PANOPTIC: COCO_PANOPTIC_INFORMATION,
     _SEMKITTI_DVPS: SEMKITTI_DVPS_INFORMATION,
+    _SCANNETV2_NYU40: SCANNETV2_NYU40_INFORMATION
 }
 
 MAP_NAMES = list(MAP_NAME_TO_DATASET_INFO.keys())


### PR DESCRIPTION
When creating panoptic maps for scannet V2, set the instance ids 
of stuff classes to zero before normalizing instance i.e. remapping
them in the range [1, num_instances].